### PR TITLE
Make the repo run straight away

### DIFF
--- a/ACF/CombinationFramework.cpp
+++ b/ACF/CombinationFramework.cpp
@@ -69,15 +69,15 @@ int main(int argc, char** argv)
         //NMS
         DetectionList NMax = NMS.dollarNMS(DL);
 
-        // cout<<t.count()<<endl;
+        cout<<t.count()<<endl;
         //Write detections to file
         NMax.WriteDetections(cnt, FW, FP->getFilename());
 
         // Draw the detections and show them
         NMax.Draw(Frame, output, cnt);
-        //cv::imshow("Frame", Frame);
+        cv::imshow("Frame", Frame);
 
-        //cv::waitKey(0);
+        cv::waitKey(0);
     }
 
     delete FP;

--- a/ACF/DetectionList.h
+++ b/ACF/DetectionList.h
@@ -61,8 +61,8 @@ public:
         srand(time(NULL));
         std::string fn1, fn2;
         tostring(cnt, fn1);
-        return;
-		for (int d = 0; d < Ds.size(); d++) {
+        //return;
+	for (int d = 0; d < Ds.size(); d++) {
             cv::Rect myROI(Ds[d]->getX(),
                 Ds[d]->getY(),
                 Ds[d]->getWidth(),
@@ -70,7 +70,7 @@ public:
             cv::Mat croppedRef(Frame, myROI);
             tostring(d + 1, fn2);
             cv::imwrite(dir + fn1 + "-" + fn2 + ".jpg", croppedRef);
-            //cv::rectangle(Frame,cv::Point(Ds[d]->getX(), Ds[d]->getY()), cv::Point(Ds[d]->getX()+Ds[d]->getWidth(), Ds[d]->getY()+Ds[d]->getHeight()), Ds[d]->getColor(),3);
+            cv::rectangle(Frame,cv::Point(Ds[d]->getX(), Ds[d]->getY()), cv::Point(Ds[d]->getX()+Ds[d]->getWidth(), Ds[d]->getY()+Ds[d]->getHeight()), Ds[d]->getColor(),3);
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ And I used it a long time ago, **code for training the model is lost** ...
 
 detect person in image and crop them
 
-    ./ped_det_acf_crop path/to/image/dir output/path
+    ./ped_acf path/to/image/dir output/path
 
+The arguments must be directories, not individual files
 
 ## [Citations]
 *  Open Framework for combined pedestrian detection

--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@ I made some modifications to it for my own use.
 And I used it a long time ago, **code for training the model is lost** ...
 
 ## [Usage]
-Compile with the standard cmake and make procedure
+Compile with the standard cmake and make procedure.
 
-Detect person in image and crop them
+Detect person in image and crop them using:
 
     ./ped_acf path/to/image/dir output/path
 
-The arguments must be directories, not individual files
+The arguments must be directories, not individual files.
+
+Results will be shown on the screen, cropped and saved in the output path, as well as written to the detections.xml file.
 
 ## [Citations]
 *  Open Framework for combined pedestrian detection
@@ -23,4 +25,5 @@ The arguments must be directories, not individual files
 
 ## [Common Bugs]
 You may need to replace cv::vector with std::vector if using OpenCV 3.
+
 It may also be necessary to add "using namespace std;" into the gpu.hpp file inside OpenCV.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ I made some modifications to it for my own use.
 And I used it a long time ago, **code for training the model is lost** ...
 
 ## [Usage]
+Compile with the standard cmake and make procedure
 
-detect person in image and crop them
+Detect person in image and crop them
 
     ./ped_acf path/to/image/dir output/path
 
@@ -19,3 +20,7 @@ The arguments must be directories, not individual files
 
 *  On-board real-time tracking of pedestrians on a UAV
    F. De Smedt, D. Hulens and T. Goedemé, EVW 2015, Boston, USA
+
+## [Common Bugs]
+You may need to replace cv::vector with std::vector if using OpenCV 3.
+It may also be necessary to add "using namespace std;" into the gpu.hpp file inside OpenCV.


### PR DESCRIPTION
A couple of minor things in the code mean that when first cloned, the repo doesn't actually seem to behave the way the readme suggests. The results are only shown in the detections.xml, which isn't very readable or intuitive to someone trying to see if this repo works quickly. These changes mean that it will at least work by default, and then developers can comment out the parts they don't need.